### PR TITLE
Infinity and NaN checks

### DIFF
--- a/CoreUtils.Tests/ThrowHelpers/ReturnParameter/OrThrowIfInfinityOrNaN.Tests.cs
+++ b/CoreUtils.Tests/ThrowHelpers/ReturnParameter/OrThrowIfInfinityOrNaN.Tests.cs
@@ -1,0 +1,50 @@
+﻿namespace System1Group.Lib.CoreUtils.Tests
+{
+    using System;
+    using NUnit.Framework;
+
+    public class Throw_OrThrowIfInfinityOrNaN_Tests
+    {
+        [Test]
+        public void Ok_Zero()
+        {
+            Assert.DoesNotThrow(() => ReturnParameter.OrThrowIfInfinityOrNaN(0.0, "testString"));
+            Assert.AreEqual(0.0, ReturnParameter.OrThrowIfInfinityOrNaN(0.0, "testString"));
+        }
+
+        [Test]
+        public void Ok_Positive()
+        {
+            Assert.DoesNotThrow(() => ReturnParameter.OrThrowIfInfinityOrNaN(1.3, "testString"));
+            Assert.AreEqual(1.3, ReturnParameter.OrThrowIfInfinityOrNaN(1.3, "testString"));
+        }
+
+        [Test]
+        public void Ok_Negative()
+        {
+            Assert.DoesNotThrow(() => ReturnParameter.OrThrowIfInfinityOrNaN(-1.3, "testString"));
+            Assert.AreEqual(-1.3, ReturnParameter.OrThrowIfInfinityOrNaN(-1.3, "testString"));
+        }
+
+        [Test]
+        public void ThrowForPositiveInfinity()
+        {
+            var x = Assert.Throws<ArgumentException>(() => ReturnParameter.OrThrowIfInfinityOrNaN(double.PositiveInfinity, "testString"));
+            Assert.That(x.Message, Does.StartWith("Value should not be infinity"));
+        }
+
+        [Test]
+        public void ThrowForNegativeInfinity()
+        {
+            var x = Assert.Throws<ArgumentException>(() => ReturnParameter.OrThrowIfInfinityOrNaN(double.NegativeInfinity, "testString"));
+            Assert.That(x.Message, Does.StartWith("Value should not be infinity"));
+        }
+
+        [Test]
+        public void ThrowForNaN()
+        {
+            var x = Assert.Throws<ArgumentException>(() => ReturnParameter.OrThrowIfInfinityOrNaN(double.NaN, "testString"));
+            Assert.That(x.Message, Does.StartWith("Value should not be NaN"));
+        }
+    }
+}

--- a/CoreUtils.Tests/ThrowHelpers/Throw/IfInfinityOrNaN.Tests.cs
+++ b/CoreUtils.Tests/ThrowHelpers/Throw/IfInfinityOrNaN.Tests.cs
@@ -1,0 +1,47 @@
+﻿namespace System1Group.Lib.CoreUtils.Tests
+{
+    using System;
+    using NUnit.Framework;
+
+    public class Throw_IfInfinityOrNaN_Tests
+    {
+        [Test]
+        public void Ok_Zero()
+        {
+            Assert.DoesNotThrow(() => Throw.IfInfinityOrNaN(0.0, "testString"));
+        }
+
+        [Test]
+        public void Ok_Positive()
+        {
+            Assert.DoesNotThrow(() => Throw.IfInfinityOrNaN(1.3, "testString"));
+        }
+
+        [Test]
+        public void Ok_Negative()
+        {
+            Assert.DoesNotThrow(() => Throw.IfInfinityOrNaN(-1.3, "testString"));
+        }
+
+        [Test]
+        public void ThrowForPositiveInfinity()
+        {
+            var x = Assert.Throws<ArgumentException>(() => Throw.IfInfinityOrNaN(double.PositiveInfinity, "testString"));
+            Assert.That(x.Message, Does.StartWith("Value should not be infinity"));
+        }
+
+        [Test]
+        public void ThrowForNegativeInfinity()
+        {
+            var x = Assert.Throws<ArgumentException>(() => Throw.IfInfinityOrNaN(double.NegativeInfinity, "testString"));
+            Assert.That(x.Message, Does.StartWith("Value should not be infinity"));
+        }
+
+        [Test]
+        public void ThrowForNaN()
+        {
+            var x = Assert.Throws<ArgumentException>(() => Throw.IfInfinityOrNaN(double.NaN, "testString"));
+            Assert.That(x.Message, Does.StartWith("Value should not be NaN"));
+        }
+    }
+}

--- a/CoreUtils/ThrowHelpers/ReturnParameter.cs
+++ b/CoreUtils/ThrowHelpers/ReturnParameter.cs
@@ -39,5 +39,11 @@ namespace System1Group.Lib.CoreUtils
             Throw.IfWhitespace(value, paramName);
             return value;
         }
+
+        public static double OrThrowIfInfinityOrNaN(double value, string paramName)
+        {
+            Throw.IfInfinityOrNaN(value, paramName);
+            return value;
+        }
     }
 }

--- a/CoreUtils/ThrowHelpers/Throw.cs
+++ b/CoreUtils/ThrowHelpers/Throw.cs
@@ -63,6 +63,19 @@
             }
         }
 
+        public static void IfInfinityOrNaN(double value, string paramName)
+        {
+            if (double.IsNaN(value))
+            {
+                throw new ArgumentException("Value should not be NaN", paramName);
+            }
+
+            if (double.IsInfinity(value))
+            {
+                throw new ArgumentException("Value should not be infinity", paramName);
+            }
+        }
+
         private static void IfEmpty(string value, string paramName)
         {
             if (string.CompareOrdinal(value, string.Empty) == 0)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Throw.IfNullOrEmpty(str, nameof(str)); // Throws ArgumentException
 // Other variations are:
 // - Throw.IfNullEmptyOrWhitespace
 // - Throw.IfEmptyOrWhitespace
+// - Throw.IfInfinityOrNaN
 ```
 
 ### ReturnParameter
@@ -34,6 +35,7 @@ var str3 = ReturnParameter.OrThrowIfNull(str, nameof(str)); // Throws ArgumentNu
 //  - ReturnParameter.OrThrowIfNullEmptyOrWhitespace
 //  - ReturnParameter.OrThrowIfNullOrEmpty
 //  - ReturnParameter.OrThrowIfEmptyOrWhitespace
+//  - ReturnParameter.OrThrowIfInfinityOrNaN
 ```
 
 ## LazyValue


### PR DESCRIPTION
I ran into some issues with The Crunch where I missed a divide by zero check which resulted in a method returning infinity. No errors were thrown until the data got passed to Nancy to display as json which it did not like and gave a slightly unhelpful error.

Thought we could implement this check on doubles to avoid this in the future.